### PR TITLE
Updated to latest inline_forms with versions funtionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'capistrano-rails', '~> 1.3', require: false
 gem 'capistrano-bundler', '~> 1.3', require: false
 gem 'rvm1-capistrano3', require: false
 gem 'capistrano3-unicorn'
+gem 'jquery-timepicker-rails'
 
 group :development do
   gem 'yaml_db'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
-    inline_forms (5.0.22)
+    inline_forms (5.1.0)
       rails (>= 5.0)
       rails-i18n
       rvm
@@ -149,6 +149,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-timepicker-rails (1.11.10)
+      railties (>= 3.1.0)
     jquery-ui-rails (4.0.3)
       jquery-rails
       railties (>= 3.1.0)
@@ -336,6 +338,7 @@ DEPENDENCIES
   i18n-active_record!
   inline_forms (>= 5)
   jquery-rails
+  jquery-timepicker-rails
   jquery-ui-sass-rails
   lightbox2-rails
   listen

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,47 +6,57 @@ Rails.application.routes.draw do
 
   resources :images do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   resources :begrips do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   resources :assignments do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   resources :documents do
     post 'revert', on: :member
+    get 'list_versions', :on => :member
     get  'view',   on: :member, as: :view
   end
 
   resources :inline_forms_translations do
+    get 'list_versions', :on => :member
     post 'revert', :on => :member
   end
 
   resources :inline_forms_keys do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   resources :inline_forms_locales do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   mount Ckeditor::Engine => '/ckeditor'
 
   resources :roles do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   resources :locales do
     post 'revert', :on => :member
+    get 'list_versions', :on => :member
   end
 
   devise_for :users, :path_prefix => 'auth'
 
   resources :users do
-      post 'revert', :on => :member
+    post 'revert', :on => :member
+    get 'list_versions', :on => :member      
   end
 
 


### PR DESCRIPTION
This PR

- Updates to inline_forms (5.1.0)
- Adds inline_forms dependency 'jquery-timepicker-rails'
- Adds route needed for versions funcionality 