### PR TITLE
Updated store dir path and Ckeditor athorization

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,10 @@ class Ability
         can :access_but_not_delete, :all
         can :view, Document
         can :destroy, [Begrip, Assignment, Image]
+        can :access, :ckeditor   # needed to access Ckeditor filebrowser
+        # Performed checks for actions:
+        can [:read, :create, :destroy], Ckeditor::Picture
+        can [:read, :create, :destroy], Ckeditor::AttachmentFile
     elsif user.role? :student
       can :read, [Document, Assignment, Begrip]
       cannot [:create, :update, :delete, :index], :all

--- a/app/uploaders/ckeditor_attachment_file_uploader.rb
+++ b/app/uploaders/ckeditor_attachment_file_uploader.rb
@@ -18,7 +18,7 @@ class CkeditorAttachmentFileUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "public/uploads/ckeditor/attachments/#{model.id}"
+    "uploads/ckeditor/attachments/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/uploaders/ckeditor_picture_uploader.rb
+++ b/app/uploaders/ckeditor_picture_uploader.rb
@@ -16,7 +16,7 @@ class CkeditorPictureUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "public/uploads/ckeditor/pictures/#{model.id}"
+    "uploads/ckeditor/pictures/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -14,7 +14,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "public/uploads/masonry/images/#{model.id}"
+    "uploads/masonry/images/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -23,7 +23,7 @@ Ckeditor.setup do |config|
 
   # Setup authorization to be run as a before filter
   # By default: there is no authorization.
-  # config.authorize_with :cancan
+  config.authorize_with :cancan
 
   # Override parent controller CKEditor inherits from
   # By default: 'ApplicationController'


### PR DESCRIPTION
No need to add public to the store dir path. I tested this on http://sazon.abclink.info/view/sazon and the pictures show up. On my server the uploads folder is on shared/public. 

![sazonimages](https://user-images.githubusercontent.com/413133/36185745-33c4bb5e-1111-11e8-8515-9c882b3a7227.png)
