### PR TITLE
Added RelatedWord model in order to replace the synonym column on the Begrip model

### DIFF
--- a/app/controllers/related_words_controller.rb
+++ b/app/controllers/related_words_controller.rb
@@ -1,0 +1,2 @@
+class RelatedWordsController < InlineFormsController
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,12 +11,12 @@ module ApplicationHelper
     content_begrips = content.scan(/_.+?_/).sort
     content_begrips.each do |needle|
       clean_needle = needle.gsub('_','')
-      begrip = Begrip.find_by(name: Nokogiri::HTML.parse(clean_needle).text)
+      begrip = Begrip.find_by_name(Nokogiri::HTML.parse(clean_needle).text)
       if begrip.nil?
         content = content.gsub(needle, clean_needle)
       else
         if format == 'html'
-          description = "#{begrip.description.gsub('"', "&quot;")}" + (begrip.synonym.blank? ? '' : "<br /><br />Synoniemen: #{begrip.synonym}")
+          description = "#{begrip.name}<br /><br />#{begrip.description.gsub('"', "&quot;")}" + begrip.related_words_text('<br /><br />Related words: ')
           content = content.gsub(needle, "<span data-tooltip data-options=\"hover_delay: 10;\" aria-haspopup=\"true\" class=\"has-tip radius\" title=\"#{description}\">#{clean_needle}</span>")
         elsif format == 'pdf'
           content = content.gsub(needle, "<span class='pdf_begrip'>#{clean_needle}</span>")

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -86,9 +86,14 @@ class Document < ActiveRecord::Base
   end
 
   def begrips
+    begrips = []
     content = self.content + images.all.map {|i| i.description }.join
     content.gsub!(/\/uploads\/ckeditor\/pictures\/([0-9]+)\/content_/,'/uploads/ckeditor/pictures/\1/content-')
-    content.downcase.scan(/_.+?_/).map {|x|Nokogiri::HTML.parse(x.gsub('_','')).text}.uniq.sort
+    text_begrips = content.downcase.scan(/_.+?_/).map {|x|Nokogiri::HTML.parse(x.gsub('_','')).text}
+
+    begrips << Begrip.where(name: text_begrips)
+    begrips << Begrip.joins(:related_words).where(related_words: { name: text_begrips } )
+    begrips.flatten.uniq.sort
   end
 
   def inline_forms_attribute_list

--- a/app/models/related_word.rb
+++ b/app/models/related_word.rb
@@ -1,0 +1,28 @@
+class RelatedWord < ApplicationRecord
+  attr_reader :per_page
+  @per_page = 7
+  attr_writer :inline_forms_attribute_list
+  has_paper_trail
+
+  belongs_to :begrip
+
+  def _presentation
+    "#{name}"
+  end
+
+
+  def inline_forms_attribute_list
+    @inline_forms_attribute_list ||= [
+      [ :name , "name", :text_field ],
+    ]
+  end
+
+
+  def self.not_accessible_through_html?
+    true
+  end
+
+  def self.order_by_clause
+    nil
+  end
+end

--- a/app/views/documents/view.html.erb
+++ b/app/views/documents/view.html.erb
@@ -105,17 +105,15 @@
     <% end %>
 
     <% unless @document.id == 33 # begrippen %>
-      <% begrips = @document.begrips
-         begrips = Begrip.where(name: begrips) %>
-      <% unless begrips.empty? %>
+      <% unless @document.begrips.empty? %>
         <div class="row begrippen">
           <h3>BEGRIPPEN</h3>
           <ul>
-            <% begrips.each do |begrip| %>
+            <% @document.begrips.each do |begrip| %>
               <li>
                 <span data-tooltip data-options="hover_delay: 10;" aria-haspopup="true" class="has-tip tip-bottom radius" title="
                 <%= begrip.description %>
-                <%= begrip.synonym.blank? ? '' : "<br /><br />Synoniemen: #{begrip.synonym}" %>
+                <%= begrip.related_words_text('<br /><br />Related words: ') %>
                 "><%= begrip.name %></span>
               </li>
             <% end %>

--- a/app/views/documents/view.pdf.erb
+++ b/app/views/documents/view.pdf.erb
@@ -105,7 +105,7 @@
               <li>
                 <h2><%= begrip.name %></h2>
                 <%= begrip.description.html_safe %>
-                <%= begrip.synonym.blank? ? '' : "<br /><br />Synoniemen: #{begrip.synonym}" %>
+                <%= begrip.related_words_text('<br /><br />Related words: ') %>
               </li>
             <% end %>
           </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,9 @@ en:
       begrip:
         name: begrip
         description: beschrijving
-        synonym: synoniemen. Indien meerdere, zet er een ',' tussen!
+        related_words: Gerelateerde woorden
+      related_word:
+        name: woord
       document:
         name: interne naam, bepaalt volgorde
         slug: naam voor url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
 
+  resources :related_words do
+  post 'revert', :on => :member
+  get 'list_versions', :on => :member
+end
+
   get 'errors/not_found'
 
   get 'errors/internal_server_error'

--- a/db/migrate/20180414002020_inline_forms_create_related_words.rb
+++ b/db/migrate/20180414002020_inline_forms_create_related_words.rb
@@ -1,0 +1,41 @@
+class InlineFormsCreateRelatedWords < ActiveRecord::Migration[5.0]
+
+  def self.up
+    create_table :related_words do |t|
+      t.string :name
+      t.belongs_to :begrip
+      t.timestamps
+    end
+
+    Begrip.all.each do |begrip|
+      next if begrip.synonym.nil?
+      synonyms = begrip.synonym.split(/[,;]/).map { |s| s.strip.downcase }
+      synonyms.each do |synonym|
+        related_word = RelatedWord.find_by_name(synonym)
+        # the related word already exists but it belongs to another begrip
+        # NOT GOOD
+        if !related_word.nil? && related_word.begrip_id != begrip.id
+          say "#{synonym} belongs to #{related_word.begrip_id} and #{begrip.id}"
+        # the related word no exits, so let's create it
+        elsif related_word.nil?
+          begrip.related_words.create(name: synonym)
+        end
+      end
+    end
+
+    remove_column :begrips, :synonym
+  end
+
+  def self.down
+    add_column :begrips, :synonym, :string
+
+    Begrip.all.each do |begrip|
+      next if begrip.related_words.empty?
+      begrip.synonym = begrip.related_words.map(&:name).join(',')
+      begrip.save
+    end
+
+    drop_table :related_words
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,99 +10,106 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170826144509) do
+ActiveRecord::Schema.define(version: 20180414002020) do
 
-  create_table "assignments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.string   "title"
-    t.text     "content",     limit: 65535
-    t.integer  "document_id"
+  create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "title"
+    t.text "content"
+    t.integer "document_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "begrips", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.text     "description", limit: 65535
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "synonym"
-  end
-
-  create_table "ckeditor_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "data_file_name",               null: false
-    t.string   "data_content_type"
-    t.integer  "data_file_size"
-    t.string   "type",              limit: 30
-    t.integer  "width"
-    t.integer  "height"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.index ["type"], name: "index_ckeditor_assets_on_type", using: :btree
-  end
-
-  create_table "documents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.string   "title"
-    t.integer  "document_id"
-    t.text     "content",              limit: 65535
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text     "sidebar",              limit: 65535
-    t.integer  "sidebar_on",                         default: 1
-    t.string   "slug"
-    t.text     "css",                  limit: 65535
-    t.integer  "masonry_title_above",                default: 1
-    t.integer  "masonry_text_above",                 default: 1
-    t.integer  "masonry_column_width",               default: 200
-    t.integer  "masonry_gutter_width",               default: 10
-    t.integer  "which_menu",                         default: 1
-  end
-
-  create_table "images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.string   "caption"
-    t.string   "image"
-    t.text     "description",           limit: 65535
-    t.integer  "document_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "lightbox_show_picture",               default: 1
-  end
-
-  create_table "inline_forms_keys", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
+  create_table "begrips", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "inline_forms_locales", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.integer  "inline_forms_translations_id"
+  create_table "ckeditor_assets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "data_file_name", null: false
+    t.string "data_content_type"
+    t.integer "data_file_size"
+    t.string "type", limit: 30
+    t.integer "width"
+    t.integer "height"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["type"], name: "index_ckeditor_assets_on_type"
+  end
+
+  create_table "documents", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "title"
+    t.integer "document_id"
+    t.text "content"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.text "sidebar"
+    t.integer "sidebar_on", default: 1
+    t.string "slug"
+    t.text "css"
+    t.integer "masonry_title_above", default: 1
+    t.integer "masonry_text_above", default: 1
+    t.integer "masonry_column_width", default: 200
+    t.integer "masonry_gutter_width", default: 10
+    t.integer "which_menu", default: 1
+  end
+
+  create_table "images", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "caption"
+    t.string "image"
+    t.text "description"
+    t.integer "document_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "lightbox_show_picture", default: 1
+  end
+
+  create_table "inline_forms_keys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "inline_forms_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.integer  "inline_forms_key_id"
-    t.integer  "inline_forms_locale_id"
-    t.text     "value",                  limit: 65535
-    t.text     "interpolations",         limit: 65535
-    t.boolean  "is_proc"
+  create_table "inline_forms_locales", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.integer "inline_forms_translations_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "locales", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.string   "title"
+  create_table "inline_forms_translations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.integer "inline_forms_key_id"
+    t.integer "inline_forms_locale_id"
+    t.text "value"
+    t.text "interpolations"
+    t.boolean "is_proc"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name"
-    t.text     "description", limit: 65535
+  create_table "locales", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "title"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "related_words", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.integer "begrip_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["begrip_id"], name: "index_related_words_on_begrip_id"
+  end
+
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -112,33 +119,33 @@ ActiveRecord::Schema.define(version: 20170826144509) do
     t.integer "user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "name"
-    t.integer  "locale_id"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "name"
+    t.integer "locale_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string   "item_type",  limit: 191,        null: false
-    t.integer  "item_id",                       null: false
-    t.string   "event",                         null: false
-    t.string   "whodunnit"
-    t.text     "object",     limit: 4294967295
+  create_table "versions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string "item_type", limit: 191, null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object", limit: 4294967295
     t.datetime "created_at"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
 end


### PR DESCRIPTION
This PR adds

* a RelatedWord model. It's migration also move data from the Begrip synonym column to the new model's table. it's migration also remove the Begrip synonym column.
* Updates logic associated to the synonym functionality to the new data model
* Related words also can be used as a begrip: _relatedword_ this will add a tooltip with the data from the Begrip this related word belongs to