### PR TITLE
Added isms as special kind of begrip

### DIFF
--- a/app/assets/stylesheets/sazon.scss
+++ b/app/assets/stylesheets/sazon.scss
@@ -91,6 +91,14 @@ nav#sazon_top_bar, #sazon_top_bar_container {
   padding: 20px;
 }
 
+.row.isms {
+  background: rgba(255, 255, 255, 0.70) none repeat scroll 0 0;
+  border: 4px solid #7a3372;
+  border-radius: 25px 25px 25px 0;
+  margin-bottom: 30px;
+  padding: 20px;
+}
+
 .quote {
   border-left: 10px solid #3a5182;
   margin-bottom: 35px;

--- a/app/models/begrip.rb
+++ b/app/models/begrip.rb
@@ -8,6 +8,9 @@ class Begrip < ActiveRecord::Base
 
   default_scope { order :name }
 
+  scope :exclude_isms, -> { where(is_ism: 0) }
+  scope :only_isms, -> { where(is_ism: 1) }
+
   def _presentation
     name + related_words_text('(',')')
   end
@@ -23,6 +26,7 @@ class Begrip < ActiveRecord::Base
     @inline_forms_attribute_list ||= [
       [ :name , "het begrip", :text_field ],
       [ :description , "de beschrijving", :text_area_without_ckeditor ],
+      [ :is_ism, 'is_ism', :radio_button, { 0 => 'no', 1 => 'yes' } ],
       [ :related_words , "het begrip", :associated ],
     ]
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -87,13 +87,22 @@ class Document < ActiveRecord::Base
 
   def begrips
     begrips = []
+    begrips << Begrip.exclude_isms.where(name: text_begrips)
+    begrips << Begrip.exclude_isms.joins(:related_words).where(related_words: { name: text_begrips } )
+    begrips.flatten.uniq.sort
+  end
+
+  def isms
+    isms = []
+    isms << Begrip.only_isms.where(name: text_begrips)
+    isms << Begrip.only_isms.joins(:related_words).where(related_words: { name: text_begrips } )
+    isms.flatten.uniq.sort
+  end
+
+  def text_begrips
     content = self.content + images.all.map {|i| i.description }.join
     content.gsub!(/\/uploads\/ckeditor\/pictures\/([0-9]+)\/content_/,'/uploads/ckeditor/pictures/\1/content-')
-    text_begrips = content.downcase.scan(/_.+?_/).map {|x|Nokogiri::HTML.parse(x.gsub('_','')).text}
-
-    begrips << Begrip.where(name: text_begrips)
-    begrips << Begrip.joins(:related_words).where(related_words: { name: text_begrips } )
-    begrips.flatten.uniq.sort
+    content.downcase.scan(/_.+?_/).map {|x|Nokogiri::HTML.parse(x.gsub('_','')).text}
   end
 
   def inline_forms_attribute_list

--- a/app/views/documents/view.html.erb
+++ b/app/views/documents/view.html.erb
@@ -121,6 +121,24 @@
         </div>
       <% end %>
     <% end %>
+
+    <% unless @document.id == 33 # begrippen %>
+      <% unless @document.isms.empty? %>
+        <div class="row isms">
+          <h3>ISMEN</h3>
+          <ul>
+            <% @document.isms.each do |ism| %>
+              <li>
+                <span data-tooltip data-options="hover_delay: 10;" aria-haspopup="true" class="has-tip tip-bottom radius" title="
+                <%= ism.description %>
+                <%= ism.related_words_text('<br /><br />Related words: ') %>
+                "><%= ism.name %></span>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>
 <% content_for :javascript do %>

--- a/db/migrate/20180422025523_add_is_ism_to_begrips.rb
+++ b/db/migrate/20180422025523_add_is_ism_to_begrips.rb
@@ -1,0 +1,9 @@
+class AddIsIsmToBegrips < ActiveRecord::Migration[5.1]
+  def up
+    add_column :begrips, :is_ism, :integer, null: false, default: 0
+  end
+
+  def down
+    remove_column :begrips, :is_ism, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180414002020) do
+ActiveRecord::Schema.define(version: 20180422025523) do
 
   create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20180414002020) do
     t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer "is_ism", default: 0, null: false
   end
 
   create_table "ckeditor_assets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|


### PR DESCRIPTION
This PR:

* Adds a is_ism column to begrips table
* Adds separated listing of begrips as isms on documents view

![begrippen](https://user-images.githubusercontent.com/413133/39091320-5292c9ba-45b7-11e8-8a58-347c11f16b30.png)
