### PR TITLE
Integrates document sidebar content into tooltips and bregrips systems

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -111,7 +111,7 @@ class Document < ActiveRecord::Base
   end
 
   def text_begrips
-    content = self.content + images.all.map {|i| i.description }.join
+    content = self.content + self.sidebar + images.all.map {|i| i.description }.join
     content.gsub!(/\/uploads\/ckeditor\/pictures\/([0-9]+)\/content_/,'/uploads/ckeditor/pictures/\1/content-')
     content.downcase.scan(/_.+?_/).map {|x|Nokogiri::HTML.parse(x.gsub('_','')).text}
   end

--- a/app/views/documents/view.html.erb
+++ b/app/views/documents/view.html.erb
@@ -92,7 +92,7 @@
 
     <% unless @document.sidebar.blank? %>
       <div class="row sidebar">
-        <%= raw @document.sidebar %>
+        <%= raw add_tooltips @document.sidebar, 'html' %>
       </div>
     <% end %>
 


### PR DESCRIPTION
This PR:

- makes 'begrips' and 'isms' get a tooltip also in the sidebar content
- makes 'begrips', existing in the sidebar content, show up in the 'begrips' section.

**Begrip tooltip in the sidebar content**
![begrep_tooltip_in_sidebar](https://user-images.githubusercontent.com/413133/42738692-680dc2b2-884d-11e8-82c0-728889bd454f.png)
**Begrip from the sidebar content in the 'begrips' section
![begrip_from_the_sidebar_content](https://user-images.githubusercontent.com/413133/42738703-9c4e3dd6-884d-11e8-965b-c1fe34b687da.png)
