### PR TITLE
Added pagebreaks before each chapter in the pdf version

### DIFF
--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -1,8 +1,19 @@
+/* Page Breaks */
+.pb_before { page-break-before:always !important; }
+.pb_after  { page-break-after:always !important; }
+.pbi_avoid { page-break-inside:avoid !important; }
+
+/*
+
 @import url(https://fonts.googleapis.com/css?family=Dosis:400,400italic);
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,400italic);
 
+*/
 
 /* Reset CSS. http://yui.yahooapis.com/3.2.0/build/cssreset/reset-min.css  */
+
+/*
+
 html{color:#000;background:#FFF;}
 body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}
 table{border-collapse:collapse;border-spacing:0;width: 100%;}
@@ -13,11 +24,6 @@ caption,th{text-align:left;}
 h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}
 q:before,q:after{content:'';}
 legend{color:#000;}
-
-/* Page Breaks */
-.pb_before { page-break-before:always !important; }
-.pb_after  { page-break-after:always !important; }
-.pbi_avoid { page-break-inside:avoid !important; }
 
 #sazon_pdf_outer_container {
 
@@ -61,13 +67,11 @@ legend{color:#000;}
 
 .pdf_masonry_image {
   float: left;
-  padding: 20px 25px 0 0;
+  padding: 5px 25px 0 0;
 }
 .pdf_masonry_content {
   float: left;
   width: 70%;
-  padding: 20px 0 0 0;
-
 }
 
 .content_area.column.medium-8.large-9 {
@@ -140,3 +144,5 @@ legend{color:#000;}
 .masonry_image {
   margin-top: 10px !important;
 }
+
+*/

--- a/app/views/documents/module_view.pdf.erb
+++ b/app/views/documents/module_view.pdf.erb
@@ -3,14 +3,14 @@
     <%= render 'documents/document' %>
   </div>
   <% @document.documents.each do |document| %>
-    <div class="content_area column medium-8 large-9">
+    <div class="content_area column medium-8 large-9 pb_before">
       <%= render 'documents/subdocument', document: document %>
     </div>
   <% end %>
 </div>
 
 <% if @document.module_any_begrip_or_ism? %>
-  <div class="content_area column medium-8 large-9">
+  <div class="content_area column medium-8 large-9 pb_before">
     <div class="row content_area_title_above">
       <h1 class="title">
         List of begrips and isms for: <%= @document.this_module.title %>

--- a/app/views/layouts/pdf.pdf.erb
+++ b/app/views/layouts/pdf.pdf.erb
@@ -3,7 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>Sazon</title>
-    <%= stylesheet_link_tag "pdf" %>
+    <style>
+      <%= Rails.application.assets.find_asset('pdf.scss').to_s %>
+    </style>
 
     <script>/* foo */</script>
   </head>


### PR DESCRIPTION
@acesuares In order to achieve this I had to get styles for pdf layout working back because they weren't working. But after some exploring I decided to comment all the styles less that ones for pagebreaks. I decided that because I find the pdf looks better with less styles or a least without the styles no existing in the pdf.scss file. Please take a look on this and let me know If you find that we should do something else about this now.