### PR TITLE
Added a way to upload all kinds of files

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < InlineFormsApplicationController
     redirect_to '/view/not_found'
   end
 
-  ActionView::CompiledTemplates::MODEL_TABS = %w(assignments documents users begrips)
+  ActionView::CompiledTemplates::MODEL_TABS = %w(bestands assignments documents users begrips)
 
   # Uncomment next line if you want I18n (based on subdomain)
   # before_action :set_locale

--- a/app/controllers/bestands_controller.rb
+++ b/app/controllers/bestands_controller.rb
@@ -1,0 +1,9 @@
+class BestandsController < InlineFormsController
+  set_tab :bestand
+
+  def download
+    @bestand = Bestand.find_by(slug: params[:slug])
+    return redirect_to '/view/not_found' if @bestand.nil?
+    return redirect_to @bestand.file.url
+  end
+end

--- a/app/helpers/base_url_helper.rb
+++ b/app/helpers/base_url_helper.rb
@@ -1,0 +1,12 @@
+module BaseUrlHelper
+
+  def base_url
+    return 'https://sazon.id-arte.net' if Rails.env.production?
+    'http://localhost:3000'
+  end
+
+  def build_url(ref, params = nil)
+    "#{base_url}/#{ref}/#{params}"
+  end
+
+end

--- a/app/models/bestand.rb
+++ b/app/models/bestand.rb
@@ -1,0 +1,40 @@
+class Bestand < ApplicationRecord
+  SLUG_FORMAT = /([[:lower:]]|[0-9]+-?[[:lower:]])(-[[:lower:]0-9]+|[[:lower:]0-9])*/
+  include BaseUrlHelper
+  attr_reader :per_page
+  @per_page = 7
+  attr_writer :inline_forms_attribute_list
+  has_paper_trail
+
+  validates :name, presence: true
+  validates :slug, presence: true, format: { with: Regexp.new('\A' + SLUG_FORMAT.source + '\z'), message: "begint met een kleine letter en daarna kleine letters, koppelteken en cijfers" }
+
+  mount_uploader :file, FileUploader
+
+  def _presentation
+    "#{name}<p>#{url}<p>".html_safe
+  end
+
+  def url
+    build_url("files/#{slug}")
+  end
+
+  def inline_forms_attribute_list
+    @inline_forms_attribute_list ||= [
+      [ :name , "name", :text_field ],
+      [ :slug , "slug", :text_field ],
+      [ :file , "file", :file_field ],
+    ]
+  end
+
+
+  def self.not_accessible_through_html?
+    false
+  end
+
+  def self.order_by_clause
+    "name"
+  end
+
+
+end

--- a/app/models/bestand.rb
+++ b/app/models/bestand.rb
@@ -7,7 +7,9 @@ class Bestand < ApplicationRecord
   has_paper_trail
 
   validates :name, presence: true
-  validates :slug, presence: true, format: { with: Regexp.new('\A' + SLUG_FORMAT.source + '\z'), message: "begint met een kleine letter en daarna kleine letters, koppelteken en cijfers" }
+  validates :slug, presence: true,
+                   uniqueness: true,
+                   format: { with: Regexp.new('\A' + SLUG_FORMAT.source + '\z'), message: "begint met een kleine letter en daarna kleine letters, koppelteken en cijfers" }
 
   mount_uploader :file, FileUploader
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,5 @@
 class Document < ActiveRecord::Base
+  include BaseUrlHelper
   attr_reader :per_page
   @per_page = 999
   attr_writer :inline_forms_attribute_list
@@ -11,7 +12,9 @@ class Document < ActiveRecord::Base
   has_many :images
 
   validates :name, presence: true
-  validates :slug, presence: true, format: { with: Rails.configuration.slug_regex, message: "begint met een kleine letter en daarna kleine letters, underscore en cijfers" }
+  validates :slug, presence: true,
+                   uniqueness: true,
+                   format: { with: Rails.configuration.slug_regex, message: "begint met een kleine letter en daarna kleine letters, underscore en cijfers" }
 
   default_scope { order :name }
 
@@ -61,11 +64,7 @@ class Document < ActiveRecord::Base
   end
 
   def url
-    if Rails.env.production?
-      "https://sazon.id-arte.net/view/#{slug}"
-    else
-      "http://127.0.0.1:3001/view/#{slug}"
-    end
+    build_url("view/#{slug}")
   end
 
   def root_and_children

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+class FileUploader < CarrierWave::Uploader::Base
+  # Include RMagick or ImageScience support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+  # include CarrierWave::ImageScience
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+  "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # process :extract_dimensions
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_white_list
+    Ckeditor.attachment_file_types
+  end
+end

--- a/db/migrate/20180902161612_inline_forms_create_bestands.rb
+++ b/db/migrate/20180902161612_inline_forms_create_bestands.rb
@@ -1,0 +1,16 @@
+class InlineFormsCreateBestands < ActiveRecord::Migration[5.0]
+
+  def self.up
+    create_table :bestands do |t|
+      t.string :name 
+      t.string :slug 
+      t.string :file 
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :bestands
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180422025523) do
+ActiveRecord::Schema.define(version: 20180902161612) do
 
   create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name"
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 20180422025523) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "is_ism", default: 0, null: false
+  end
+
+  create_table "bestands", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "slug"
+    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "ckeditor_assets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
@@ -146,6 +154,7 @@ ActiveRecord::Schema.define(version: 20180422025523) do
     t.string "whodunnit"
     t.text "object", limit: 4294967295
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
This PR:

- Adds a new model `Bestand` to use it as a central place for uploading all kind of files.
- The system generates a url for each file from the slug field. This url can we use in the Documents.
- The slug for the Bestands needs to have a different format because is we use underscores, the file urls will have conflicts with the tooltips shortcode.

![bestands_index](https://user-images.githubusercontent.com/413133/44960220-1770f500-aec1-11e8-85d5-818ded0f4e3b.png)
![bestands_details](https://user-images.githubusercontent.com/413133/44960221-1770f500-aec1-11e8-9f62-dc6a37b4a696.png)
